### PR TITLE
Added Bristol job notice for WP5

### DIFF
--- a/content/posts/2022-08-19-wp5-job-advert.md
+++ b/content/posts/2022-08-19-wp5-job-advert.md
@@ -1,0 +1,25 @@
+---
+title: "New job opportunity in SWIFT-HEP (analysis) - deadline 14th Sep 2022"
+date: 2022-08-19T12:33:21+01:00
+draft: false
+start_date: 2022-08-19T12:33:21+01:00
+end_date: 2022-09-14T12:33:21+01:00
+menu:
+  main:
+    identifier: 2022-08-19-wp5-job-advert-2
+    weight: 220
+    parent: "jobs"
+---
+
+We are pleased to announce two new job openings at the **University of Bristol**.
+Both openings are within the particle physics group and will be constructed by two of the four areas below:
+
+1. Development of efficient and fast software for particle physics in the context of the **SWIFT-HEP** initiative (with a focus on Python).
+2. Software development on highly parallel computing architectures for LHCb-upgrade II, with a focus on Graphcore’s novel IPU processors (C++ -based).
+3. Data analysis at the LZ experiment (search for dark matter).
+4. Data analysis at LHCb (rare decays and CP violation).
+
+The full job advert and additional information can be found on the
+[University of Bristol job site](https://www.bristol.ac.uk/jobs/find/details/?jobId=285115&jobTitle=Research%20Associate%20/%20Senior%20Research%20Associate).
+
+The closing date for applications is the **14th of September 2022**.


### PR DESCRIPTION
This PR adds the Bristol job advert to the news items and `Jobs` navbar.
It should disappear from the news on the 14th of September (deadline) - I will keep an eye on this.