### PR TITLE
update pages once a day at midnight

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  schedule:
+    - cron: "0 0 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently, the pages are only updated on changes, which leaves awkward entries like:
![image](https://user-images.githubusercontent.com/1213276/207645543-eeb71860-9287-4c81-8923-5e9fe2c3b446.png)

when we are in the middle of December.

This PR will schedule an update once a day at midnight (in addition to pushes).