### PR TITLE
Fixing typo in title

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ pygmentsUseClasses = true
 unsafe = true
 
 [params]
-description = "SoftWare and InFrastruture Technology for High Energy Physics"
+description = "SoftWare and InFrastructure Technology for High Energy Physics"
 github_org = "https://github.com/swift-hep"
 
 sectionPagesMenu = "main"

--- a/themes/swift-hep/layouts/partials/workpackages.html
+++ b/themes/swift-hep/layouts/partials/workpackages.html
@@ -1,5 +1,5 @@
 <h2>Work packages</h2>
-<abbr title="SoftWare and InFrastruture Technology for High Energy Physics" class="initialism">SWIFT-HEP</abbr> is
+<abbr title="SoftWare and InFrastructure Technology for High Energy Physics" class="initialism">SWIFT-HEP</abbr> is
 organised in 5 work packages:
 <ol>
     {{- range where site.Pages "Type" "workpackages" -}}


### PR DESCRIPTION
Fixes #29: `InFrastruture` &rarr; `InFrastructure`