### PR TITLE
Add 9th workshop info

### DIFF
--- a/content/posts/2025-04-10-ninth-workshop.md
+++ b/content/posts/2025-04-10-ninth-workshop.md
@@ -1,0 +1,14 @@
+---
+title: "Join us for the 9th SWIFT-HEP Workshop on 10-11 April 2025"
+date: 2025-01-01T08:08:38+01:00
+draft: false
+start_date: 2025-04-10T09:00:00Z
+end_date: 2025-04-11T18:00:00Z
+---
+
+We're excited to announce that the ninth SWIFT-HEP workshop will take place on the **10th and 11th of April at the [University of Manchester](https://www.manchester.ac.uk/)**. This is a joint workshop with [GridPP](https://www.gridpp.ac.uk/), which will start on the 10th of April.
+
+Don’t miss the opportunity to connect with fellow researchers, share insights, and explore the latest in high-energy physics software and technology.
+
+For more details, including registration and the agenda, visit the [workshop website](https://indico.cern.ch/event/1476120/).
+We look forward to seeing you there!

--- a/themes/swift-hep/layouts/partials/head.html
+++ b/themes/swift-hep/layouts/partials/head.html
@@ -4,7 +4,7 @@
 
 <!-- compile CSS -->
 {{ $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" true "includePaths" (slice "node_modules/myscss")) }}
-{{ $style := resources.Get "sass/main.scss" | resources.ToCSS $options }}
+{{ $style := resources.Get "sass/main.scss" | css.Sass $options }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" media="screen">
 
 <title>


### PR DESCRIPTION
- fixed issue with `resource.ToCSS` instruction: deprecated
- added 9th workshop info